### PR TITLE
Add README and hide address in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# creamPuff
+
+This repository contains a small HTML example that hides a contact address from search engines.
+
+## Features
+
+- Displays an address decoded from a Base64 string using JavaScript.
+- Includes a `noindex` meta tag so the page is not indexed by search engines.
+
+## Usage
+
+Open `index.html` in a web browser to see the decoded address.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Cream Puff</title>
+</head>
+<body>
+    <p id="address"></p>
+    <script>
+        const encodedAddress = "c2FtcGxlQGV4YW1wbGUuY29t"; // sample@example.com in Base64
+        document.getElementById('address').textContent = atob(encodedAddress);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add README with short description and usage instructions
- add simple HTML page that hides an address using base64 and disables search engine indexing

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6844c2f369588324a6cc86dd9305c64e